### PR TITLE
Fix ScrollToTop not working

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -13,13 +13,13 @@ body {
   height: 100%;
   margin: 0px;
   padding: 0px;
-  overflow-x: hidden;
 }
 body {
   font-family: "Cabin", sans-serif;
   font-weight: 300;
   color: #505962;
   line-height: 1.5;
+  overflow-x: hidden;
 }
 h1,
 h2,


### PR DESCRIPTION
fix the scroll to top issue as the "overflow-x: hidden;" needed moving to body only and not be in the html.